### PR TITLE
Fix trial feedback: live Amex layout, Visa amount sign

### DIFF
--- a/.github/actions/visa/index.js
+++ b/.github/actions/visa/index.js
@@ -125824,10 +125824,15 @@ function run(main) {
  */
 
 /**
- * The legacy Amex export. Original Amex import logic, unchanged in behavior:
- * Merchant from Description (text before the first double space), Amount as a
- * Number, Reference stripped of quotes, City/State split, and the
+ * The legacy Amex export. Merchant from Description (text before the first
+ * double space), Amount as a Number (stripped of $ and thousands commas),
+ * Reference stripped of quotes, City/State split, and the
  * "Appears On Your Statement As" column dropped.
+ *
+ * Current live exports keep the historical header but shift the location
+ * data: City/State holds "CITY\nZIP" and the Zip Code column holds the
+ * state. Older files had "CITY\nSTATE" with the zip under Zip Code. Both
+ * layouts are accepted; a numeric second line tells them apart.
  * @type {!StatementFormat}
  */
 const AMEX_FORMAT = {
@@ -125847,16 +125852,17 @@ const AMEX_FORMAT = {
   normalizeRow(row) {
     const merchant = row['Description'].match(/(.+?)\s\s+/);
     const cityState =
-        row['City/State'].match(/(?<city>.+)\n(?<state>.+)/)?.groups;
+        row['City/State'].match(/(?<city>.+)\n(?<second>.+)/)?.groups;
+    const zipInCityState = /^\d/.test(cityState?.second ?? '');
     return {
       'Date': row['Date'],
       'Merchant': merchant ? merchant[1] : row['Description'],
-      'Amount': Number(row['Amount']),
+      'Amount': Number(row['Amount'].replace(/[$,]/g, '')),
       'Extended Details': row['Extended Details'],
       'Address': row['Address'],
       'City': cityState?.city,
-      'State': cityState?.state,
-      'Zip Code': row['Zip Code'],
+      'State': zipInCityState ? row['Zip Code'] : cityState?.second,
+      'Zip Code': zipInCityState ? cityState.second : row['Zip Code'],
       'Country': row['Country'],
       'Reference': row['Reference'].replaceAll("'", ''),
       'Category': row['Category'],
@@ -125865,8 +125871,10 @@ const AMEX_FORMAT = {
 };
 
 /**
- * The new Visa export. Its Memo column is a semicolon-delimited multi-value
- * field, e.g.:
+ * The new Visa export. It shows debits as negative amounts, the opposite of
+ * the Amex Data table's positive-charge convention, so Amount is negated
+ * (finance request, 2026-07-30). Its Memo column is a semicolon-delimited
+ * multi-value field, e.g.:
  *   `11111111111111111111111; 22222; ; DOE/JANE; SFO TO DTW ;`
  * which finance splits into: reference number; merchant #; ?; description.
  *
@@ -125885,7 +125893,7 @@ const VISA_FORMAT = {
     return {
       'Date': row['Date'],
       'Merchant': row['Name'],
-      'Amount': Number(row['Amount']),
+      'Amount': -Number(row['Amount']),
       'Extended Details': segments.slice(3).filter(Boolean).join(' '),
       'Reference': segments[0],
     };

--- a/src/visa/formats.js
+++ b/src/visa/formats.js
@@ -38,10 +38,15 @@ import Papa from 'papaparse';
  */
 
 /**
- * The legacy Amex export. Original Amex import logic, unchanged in behavior:
- * Merchant from Description (text before the first double space), Amount as a
- * Number, Reference stripped of quotes, City/State split, and the
+ * The legacy Amex export. Merchant from Description (text before the first
+ * double space), Amount as a Number (stripped of $ and thousands commas),
+ * Reference stripped of quotes, City/State split, and the
  * "Appears On Your Statement As" column dropped.
+ *
+ * Current live exports keep the historical header but shift the location
+ * data: City/State holds "CITY\nZIP" and the Zip Code column holds the
+ * state. Older files had "CITY\nSTATE" with the zip under Zip Code. Both
+ * layouts are accepted; a numeric second line tells them apart.
  * @type {!StatementFormat}
  */
 export const AMEX_FORMAT = {
@@ -61,16 +66,17 @@ export const AMEX_FORMAT = {
   normalizeRow(row) {
     const merchant = row['Description'].match(/(.+?)\s\s+/);
     const cityState =
-        row['City/State'].match(/(?<city>.+)\n(?<state>.+)/)?.groups;
+        row['City/State'].match(/(?<city>.+)\n(?<second>.+)/)?.groups;
+    const zipInCityState = /^\d/.test(cityState?.second ?? '');
     return {
       'Date': row['Date'],
       'Merchant': merchant ? merchant[1] : row['Description'],
-      'Amount': Number(row['Amount']),
+      'Amount': Number(row['Amount'].replace(/[$,]/g, '')),
       'Extended Details': row['Extended Details'],
       'Address': row['Address'],
       'City': cityState?.city,
-      'State': cityState?.state,
-      'Zip Code': row['Zip Code'],
+      'State': zipInCityState ? row['Zip Code'] : cityState?.second,
+      'Zip Code': zipInCityState ? cityState.second : row['Zip Code'],
       'Country': row['Country'],
       'Reference': row['Reference'].replaceAll("'", ''),
       'Category': row['Category'],
@@ -79,8 +85,10 @@ export const AMEX_FORMAT = {
 };
 
 /**
- * The new Visa export. Its Memo column is a semicolon-delimited multi-value
- * field, e.g.:
+ * The new Visa export. It shows debits as negative amounts, the opposite of
+ * the Amex Data table's positive-charge convention, so Amount is negated
+ * (finance request, 2026-07-30). Its Memo column is a semicolon-delimited
+ * multi-value field, e.g.:
  *   `11111111111111111111111; 22222; ; DOE/JANE; SFO TO DTW ;`
  * which finance splits into: reference number; merchant #; ?; description.
  *
@@ -99,7 +107,7 @@ export const VISA_FORMAT = {
     return {
       'Date': row['Date'],
       'Merchant': row['Name'],
-      'Amount': Number(row['Amount']),
+      'Amount': -Number(row['Amount']),
       'Extended Details': segments.slice(3).filter(Boolean).join(' '),
       'Reference': segments[0],
     };

--- a/test/local/visa/transform.test.js
+++ b/test/local/visa/transform.test.js
@@ -75,6 +75,24 @@ describe('AMEX_FORMAT.normalizeRow', () => {
     expect(out.City).toBeUndefined();
     expect(out.State).toBeUndefined();
   });
+
+  test('strips $ and thousands commas from Amount (live export)', () => {
+    expect(AMEX_FORMAT.normalizeRow(row({'Amount': '$1,050.45'})).Amount)
+        .toBe(1050.45);
+    expect(AMEX_FORMAT.normalizeRow(row({'Amount': '-$25.00'})).Amount)
+        .toBe(-25);
+  });
+
+  test('unswaps live-export layout: zip in City/State, state in Zip Code',
+      () => {
+        const out = AMEX_FORMAT.normalizeRow(row({
+          'City/State': 'SAN FRANCISCO\n94103',
+          'Zip Code': 'CA',
+        }));
+        expect(out.City).toEqual('SAN FRANCISCO');
+        expect(out.State).toEqual('CA');
+        expect(out['Zip Code']).toEqual('94103');
+      });
 });
 
 describe('VISA_FORMAT.normalizeRow', () => {
@@ -93,10 +111,17 @@ describe('VISA_FORMAT.normalizeRow', () => {
     expect(VISA_FORMAT.normalizeRow(row())).toEqual({
       'Date': '2026-07-22',
       'Merchant': 'Some Airline',
-      'Amount': -120,
+      'Amount': 120,
       'Extended Details': 'DOE/JANE 2026-07-22 SAN FRANCISCO TO DETROIT',
       'Reference': '11111111111111111111111',
     });
+  });
+
+  test('negates Amount: export debits are negative, the table stores ' +
+      'charges positive', () => {
+    expect(VISA_FORMAT.normalizeRow(row({'Amount': '-120'})).Amount).toBe(120);
+    expect(VISA_FORMAT.normalizeRow(row({'Amount': '45.50'})).Amount)
+        .toBe(-45.5);
   });
 
   test('uses the first Memo segment as the Reference key', () => {
@@ -184,6 +209,28 @@ describe('import pipeline (end to end)', () => {
     expect(row).not.toHaveProperty('City/State');
   });
 
+  // Shaped like a real 2026 export: $ amounts, multiline Extended Details,
+  // "CITY\nZIP" under City/State with the state under Zip Code, and a
+  // trailing apostrophe on the Reference.
+  test('normalizes a live-layout Amex CSV', async () => {
+    const synced = await runImport(toCsv(AMEX_FORMAT.header, [
+      [
+        '09/20/2024', 'AIRBNB * ABCD1234 SAN FRANCISCO       CA', '$1,050.45',
+        'ABCDEFGH    1234567890\nAIRBNB * ABCD1234\nSAN FRANCISCO\nCA',
+        'AIRBNB * ABCD1234 SAN FRANCISCO       CA', '1234 TEST ST',
+        'SAN FRANCISCO\n94103', 'CA', 'UNITED STATES', "389024539482049232'",
+        'Travel-Travel Agencies',
+      ],
+    ]));
+
+    expect([...synced.keys()]).toEqual(['389024539482049232']);
+    const row = synced.get('389024539482049232');
+    expect(row.Amount).toBe(1050.45);
+    expect(row.City).toEqual('SAN FRANCISCO');
+    expect(row.State).toEqual('CA');
+    expect(row['Zip Code']).toEqual('94103');
+  });
+
   test('normalizes a Visa CSV into the same common shape', async () => {
     const synced = await runImport(toCsv(VISA_FORMAT.header, [
       [
@@ -199,7 +246,7 @@ describe('import pipeline (end to end)', () => {
     // Same common-shape fields the Amex path produces.
     expect(row.Date).toEqual('2026-07-22');
     expect(row.Merchant).toEqual('Some Airline');
-    expect(row.Amount).toBe(-120);
+    expect(row.Amount).toBe(120);
     expect(row.Reference).toEqual('11111111111111111111111');
     expect(row['Extended Details'])
         .toEqual('DOE/JANE 2026-07-22 SAN FRANCISCO TO DETROIT');


### PR DESCRIPTION
Fixes the two issues reported when importing a live Amex CSV through the dual-format importer, plus the Visa amount-sign request.

## Amex: blank Amount and reversed State/Zip

Live Amex exports differ from what the importer (and the legacy amex importer before it — the transform logic was identical) expected:

- **Amount** is prefixed with `$` and can contain thousands commas (`$1,050.45`). `Number()` turned these into `NaN`, which serialized to blank in Airtable. Now stripped before conversion; plain values and negatives are unaffected.
- **City/State** contains `CITY\nZIP` with the state under the **Zip Code** column, which reversed State/Zip in the table. `normalizeRow` now detects which layout each row uses (numeric second line = zip) and maps accordingly, so both old-layout and current-layout files import correctly — cover for a possible future flip back.

Confirmed: historical prod data does not have the swap, so no backfill is needed.

## Visa: amounts negated

The Visa export shows debits as negative; the Amex Data table stores charges as positive. Amount is now negated — negation rather than `abs`, so any credit/refund rows stay distinguishable (they'd land negative).

## Testing

5 new regression tests including an end-to-end case shaped like the live Amex sample (multiline Extended Details, `$` amount, trailing-apostrophe Reference); `test/local/visa/transform.test.js` passes 22/22, offline. Rebuilt visa bundle included; its diff is exactly the source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)